### PR TITLE
Revert "chore(deps): update quay.io/openshift/origin-console docker tag to v4.18"

### DIFF
--- a/gitops/okd-console/console.yaml
+++ b/gitops/okd-console/console.yaml
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
         - name: console-app
-          image: "quay.io/openshift/origin-console:4.18"
+          image: "quay.io/openshift/origin-console:4.17"
           env:
             - name: BRIDGE_USER_AUTH
               value: disabled # no authentication required


### PR DESCRIPTION
Reverts ThomasBuchinger/voodoo-gitops#40

OKD-Console 4.18 is missing the "Network"-Section